### PR TITLE
chore: gogmocoin を v2.13.0 に更新し WS サンプルを Stream() へ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ WebSocket のサンプルは、購読・受信ループ・購読解除の共通�
 
 ```go
 client := ws.NewTicker(consts.SymbolBTCJPY)
-if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
     log.Fatal(err)
 }
 ```

--- a/app/private/ws/execution_events/main.go
+++ b/app/private/ws/execution_events/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := ws.NewExecutionEvents(true)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/private/ws/order_events/main.go
+++ b/app/private/ws/order_events/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := ws.NewOrderEvents(true)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/private/ws/position_events/main.go
+++ b/app/private/ws/position_events/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := ws.NewPositionEvents(true)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/private/ws/position_summary_events/main.go
+++ b/app/private/ws/position_summary_events/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := ws.NewPositionSummaryEvents(true, true)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/public/ws/orderbooks/main.go
+++ b/app/public/ws/orderbooks/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	client := ws.NewOrderBooks(consts.SymbolBTCJPY)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/public/ws/ticker/main.go
+++ b/app/public/ws/ticker/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	client := ws.NewTicker(consts.SymbolBTCJPY)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/app/public/ws/trades/main.go
+++ b/app/public/ws/trades/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	client := ws.NewTrades(consts.SymbolBTCJPY, nil)
-	if err := wsrunner.Run(client.Subscribe, client.Receive, client.Unsubscribe); err != nil {
+	if err := wsrunner.Run(client.Subscribe, client.Stream, client.Unsubscribe); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ijufumi/gogmocoin-examples
 go 1.25
 
 require (
-	github.com/ijufumi/gogmocoin/v2 v2.12.1
+	github.com/ijufumi/gogmocoin/v2 v2.13.0
 	github.com/joho/godotenv v1.5.1
 	github.com/shopspring/decimal v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/ijufumi/gogmocoin/v2 v2.12.1 h1:Hf0wul4s5d0cPKwi3tF8WilEOwlkzmfGmPjClHJJzsE=
-github.com/ijufumi/gogmocoin/v2 v2.12.1/go.mod h1:Rm14/41ruAEkFoP3+jUWMysArJUdHAA+CnAKhlt9hOA=
+github.com/ijufumi/gogmocoin/v2 v2.13.0 h1:qPM+/7xRHDRROyknVjNPpiIYY5+oFQpJ/XeHqE+AICg=
+github.com/ijufumi/gogmocoin/v2 v2.13.0/go.mod h1:Rm14/41ruAEkFoP3+jUWMysArJUdHAA+CnAKhlt9hOA=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/wsrunner/wsrunner.go
+++ b/internal/wsrunner/wsrunner.go
@@ -1,9 +1,8 @@
 // Package wsrunner は WebSocket サンプルで共通して使う購読ループを提供する。
 //
-// gogmocoin の WebSocket クライアントはいずれも Subscribe / Receive / Unsubscribe を
+// gogmocoin の WebSocket クライアントはいずれも Subscribe / Stream / Unsubscribe を
 // 備えており、サンプルごとに「購読 → 受信ループ → 購読解除」のコードがほぼ同一になる。
-// その重複と、Ctrl-C 時に Unsubscribe が呼ばれない問題、Receive() をループ内で
-// 何度も呼ぶことによる goroutine リークをまとめて解消するためのヘルパー。
+// その重複と、Ctrl-C 時に Unsubscribe が呼ばれない問題をまとめて解消するためのヘルパー。
 package wsrunner
 
 import (
@@ -26,9 +25,10 @@ const (
 //   - SIGINT / SIGTERM（Ctrl-C 等）を受信したとき
 //   - idleTimeout が maxIdleCount 回連続したとき
 //
-// receive は「受信チャネルを返す関数」を渡す。Receive() はチャネル取得のたびに
-// 内部で goroutine を起動するため、Subscribe 後に一度だけ呼んで使い回す。
-func Run[T any](subscribe func() error, receive func() <-chan T, unsubscribe func() error) error {
+// stream は「受信チャネルを返す関数」（クライアントの Stream() ）を渡す。
+// Stream() は Subscribe 中はチャネルを内部でメモ化して同じものを返すが、
+// このヘルパーでも Subscribe 後に一度だけ呼んで使い回す。
+func Run[T any](subscribe func() error, stream func() <-chan T, unsubscribe func() error) error {
 	if err := subscribe(); err != nil {
 		return err
 	}
@@ -42,14 +42,14 @@ func Run[T any](subscribe func() error, receive func() <-chan T, unsubscribe fun
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	stream := receive()
+	ch := stream()
 	idleCount := 0
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("signal received, shutting down...")
 			return nil
-		case v := <-stream:
+		case v := <-ch:
 			log.Printf("msg:%+v\n", v)
 		case <-time.After(idleTimeout):
 			log.Println("timeout...")


### PR DESCRIPTION
## 概要

依存ライブラリ [gogmocoin](https://github.com/ijufumi/gogmocoin) を最新版 **v2.12.1 → v2.13.0** に更新し、サンプルコードを新 API に追従させました。

## 変更内容

### バージョン更新
- `go.mod` / `go.sum` を gogmocoin v2.13.0 に更新

### API 変更への対応: `Receive()` → `Stream()`
v2.13.0 で WebSocket クライアントの `Receive()` が **非推奨（Deprecated）** となり、`Stream()` が推奨 API になりました（`Receive()` は後方互換エイリアスとして残存）。これに合わせて以下を更新:

- WS サンプル 7 本（public: ticker / orderbooks / trades、private: order_events / position_events / execution_events / position_summary_events）の `client.Receive` → `client.Stream`
- `internal/wsrunner/wsrunner.go` の引数名・コメントを `Stream()` ベースに更新。v2.13.0 では `Stream()`（内部の `RetrieveStreamOnce`）が Subscribe 中はチャネルをメモ化して同一のものを返すようになった（旧来の「呼ぶたびに goroutine 起動」問題が解消）ため、コメントを実態に合わせて修正
- `README.md` の WS サンプル例も `client.Stream` に更新

> [!NOTE]
> v2.13.0 に REST API の破壊的シグネチャ変更はなく、REST サンプルは修正不要でした。

## 検証
- `go mod tidy` ✅
- `go build ./...` ✅
- `go vet ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)